### PR TITLE
Remove outdated unit test

### DIFF
--- a/src/DeepNgToDo/Tests/Frontend/angular/services/DeepNgDoToService.spec.js
+++ b/src/DeepNgToDo/Tests/Frontend/angular/services/DeepNgDoToService.spec.js
@@ -34,10 +34,6 @@ describe('Services', function() {
     expect(deepNgToDoService.allChecked).toBe(false);
   });
 
-  it('Check createToDo() method for !title returns false', function() {
-    expect(deepNgToDoService.createToDo()).toBe(false);
-  });
-
   it('Check createToDo() with title returns promise with reponse.isError',
     function() {
       let error = null;


### PR DESCRIPTION
Remove outdated unit test for case when !title, because from createToDo() has been removed  condition below:

```
if (!title) {
  return false;
}
```
